### PR TITLE
fix(ui): add www. to the link

### DIFF
--- a/src/kong_svelte/src/lib/components/swap/swap_ui/SwapSuccessModal.svelte
+++ b/src/kong_svelte/src/lib/components/swap/swap_ui/SwapSuccessModal.svelte
@@ -40,7 +40,7 @@
     const tradeDetails = 
       `🍌 Trade completed on KongSwap!\n\n` +
       `Swapped ${formattedPaidAmount} ${payToken.symbol} for ${formattedReceivedAmount} ${receiveToken.symbol}\n\n` +
-      `Trade now: https://kongswap.io/swap?from=${payToken.canister_id}&to=${receiveToken.canister_id}\n`
+      `Trade now: https://www.kongswap.io/swap?from=${payToken.canister_id}&to=${receiveToken.canister_id}\n`
     try {
       await navigator.clipboard.writeText(tradeDetails);
       toastStore.success('Trade details copied to clipboard');


### PR DESCRIPTION
This pull request includes a minor but important change to the `SwapSuccessModal.svelte` component in the `src/kong_svelte/src/lib/components/swap/swap_ui` directory. The change updates the URL for the trade details link to ensure it includes the correct domain.

* [`src/kong_svelte/src/lib/components/swap/swap_ui/SwapSuccessModal.svelte`](diffhunk://#diff-efd2f6f226a800d079cc7eef6706246d0af9a17f11d6a488a99290e44cfdcf9dL43-R43): Updated the `Trade now` URL from `https://kongswap.io` to `https://www.kongswap.io` to ensure the correct domain is used.