### PR TITLE
Wire up `EventStoreClient`

### DIFF
--- a/src/kong_data/Cargo.toml
+++ b/src/kong_data/Cargo.toml
@@ -14,6 +14,8 @@ prod = []
 
 [dependencies]
 candid = "0.10.10"
+event_store_producer = { git = "https://github.com/open-chat-labs/event-store", rev = "v0.6.0" }
+event_store_producer_cdk_runtime = { git = "https://github.com/open-chat-labs/event-store", rev = "v0.6.0" }
 ic-cdk = "0.17.0"
 ic-cdk-timers = "0.11.0"
 ic-ledger-types = "0.14.0"

--- a/src/kong_data/src/canister.rs
+++ b/src/kong_data/src/canister.rs
@@ -1,9 +1,10 @@
-use candid::CandidType;
+use candid::{CandidType, Principal};
 use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
 use serde::Deserialize;
 
 use super::{APP_NAME, APP_VERSION};
 
+use crate::event_store_client::event_store_client;
 use crate::{ic::logging::info_log, stable_user::principal_id_map::create_principal_id_map};
 
 #[init]
@@ -11,16 +12,21 @@ async fn init() {
     info_log(&format!("{} canister has been initialized", APP_NAME));
 
     create_principal_id_map();
+
+    event_store_client::init(event_store_client::default(Principal::anonymous()));
 }
 
 #[pre_upgrade]
 fn pre_upgrade() {
     info_log(&format!("{} canister is upgrading", APP_NAME));
+
+    event_store_client::save_to_stable_memory();
 }
 
 #[post_upgrade]
 async fn post_upgrade() {
     create_principal_id_map();
+    event_store_client::load_from_stable_memory();
 
     info_log(&format!("{} canister is upgraded", APP_NAME));
 }

--- a/src/kong_data/src/canister.rs
+++ b/src/kong_data/src/canister.rs
@@ -10,7 +10,6 @@ async fn init() {
     info_log(&format!("{} canister has been initialized", APP_NAME));
 
     create_principal_id_map();
-
     event_store_client::init(event_store_client::default(Principal::anonymous()));
 }
 

--- a/src/kong_data/src/canister.rs
+++ b/src/kong_data/src/canister.rs
@@ -1,11 +1,9 @@
+use super::{APP_NAME, APP_VERSION};
+use crate::event_store_client::event_store_client;
+use crate::{ic::logging::info_log, stable_user::principal_id_map::create_principal_id_map};
 use candid::{CandidType, Principal};
 use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
 use serde::Deserialize;
-
-use super::{APP_NAME, APP_VERSION};
-
-use crate::event_store_client::event_store_client;
-use crate::{ic::logging::info_log, stable_user::principal_id_map::create_principal_id_map};
 
 #[init]
 async fn init() {

--- a/src/kong_data/src/controllers/status.rs
+++ b/src/kong_data/src/controllers/status.rs
@@ -6,9 +6,9 @@ use crate::helpers::math_helpers::{bytes_to_megabytes, to_trillions};
 use crate::ic::guards::caller_is_kingkong;
 
 use crate::stable_memory::{
-    CLAIM_MAP, CLAIM_MEMORY_ID, DB_UPDATE_MAP, DB_UPDATE_MEMORY_ID, KONG_SETTINGS_MEMORY_ID, LP_TOKEN_MAP, LP_TOKEN_MEMORY_ID,
-    MEMORY_MANAGER, POOL_MAP, POOL_MEMORY_ID, REQUEST_MAP, REQUEST_MEMORY_ID, TOKEN_MAP, TOKEN_MEMORY_ID, TRANSFER_MAP, TRANSFER_MEMORY_ID,
-    TX_MAP, TX_MEMORY_ID, USER_MAP, USER_MEMORY_ID,
+    CLAIM_MAP, CLAIM_MEMORY_ID, DB_UPDATE_MAP, DB_UPDATE_MEMORY_ID, EVENT_STORE_EVENTS_MEMORY_ID, KONG_SETTINGS_MEMORY_ID, LP_TOKEN_MAP,
+    LP_TOKEN_MEMORY_ID, MEMORY_MANAGER, POOL_MAP, POOL_MEMORY_ID, REQUEST_MAP, REQUEST_MEMORY_ID, TOKEN_MAP, TOKEN_MEMORY_ID, TRANSFER_MAP,
+    TRANSFER_MEMORY_ID, TX_MAP, TX_MEMORY_ID, USER_MAP, USER_MEMORY_ID,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -63,6 +63,7 @@ async fn status() -> Result<String, String> {
             "Stable - Transfer Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(TRANSFER_MEMORY_ID).size())),
             "Stable - Claim Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(CLAIM_MEMORY_ID).size())),
             "Stable - LP Tokens Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(LP_TOKEN_MEMORY_ID).size())),
+            "Stable - EventStore Events": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(EVENT_STORE_EVENTS_MEMORY_ID).size())),
             "Stable - DB Update Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(DB_UPDATE_MEMORY_ID).size())),
             "# of users": get_number_of_users(),
             "# of tokens": get_number_of_tokens(),

--- a/src/kong_data/src/controllers/status.rs
+++ b/src/kong_data/src/controllers/status.rs
@@ -63,7 +63,7 @@ async fn status() -> Result<String, String> {
             "Stable - Transfer Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(TRANSFER_MEMORY_ID).size())),
             "Stable - Claim Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(CLAIM_MEMORY_ID).size())),
             "Stable - LP Tokens Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(LP_TOKEN_MEMORY_ID).size())),
-            "Stable - EventStore Events": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(EVENT_STORE_EVENTS_MEMORY_ID).size())),
+            "Stable - EventStore": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(EVENT_STORE_EVENTS_MEMORY_ID).size())),
             "Stable - DB Update Map": format!("{} x 64k WASM page", MEMORY_MANAGER.with(|m| m.borrow().get(DB_UPDATE_MEMORY_ID).size())),
             "# of users": get_number_of_users(),
             "# of tokens": get_number_of_tokens(),

--- a/src/kong_data/src/event_store_client/event_store_client.rs
+++ b/src/kong_data/src/event_store_client/event_store_client.rs
@@ -1,0 +1,51 @@
+use crate::stable_memory::{with_memory, with_memory_mut, EVENT_STORE_EVENTS_MEMORY_ID};
+use candid::Principal;
+use event_store_producer::{Event, EventStoreClient, EventStoreClientBuilder};
+use event_store_producer_cdk_runtime::CdkRuntime;
+use ic_stable_structures::reader::{BufferedReader, Reader};
+use ic_stable_structures::writer::{BufferedWriter, Writer};
+use std::cell::RefCell;
+
+const ONE_MB: usize = 1024 * 1024;
+
+thread_local! {
+    static EVENT_STORE_CLIENT: RefCell<Option<EventStoreClient<CdkRuntime>>> = RefCell::default();
+}
+
+pub fn init(event_store_client: EventStoreClient<CdkRuntime>) {
+    EVENT_STORE_CLIENT.set(Some(event_store_client));
+}
+
+pub fn default(event_store_canister_id: Principal) -> EventStoreClient<CdkRuntime> {
+    EventStoreClientBuilder::new(event_store_canister_id, CdkRuntime::default()).build()
+}
+
+pub fn push_event(event: Event) {
+    EVENT_STORE_CLIENT.with_borrow_mut(|client| {
+        if let Some(client) = client {
+            client.push(event);
+        }
+    });
+}
+
+pub fn save_to_stable_memory() {
+    if let Some(client) = EVENT_STORE_CLIENT.take() {
+        with_memory_mut(EVENT_STORE_EVENTS_MEMORY_ID, |memory| {
+            let writer = BufferedWriter::new(ONE_MB, Writer::new(memory, 0));
+            _ = serde_cbor::to_writer(writer, &client);
+        });
+    }
+}
+
+pub fn load_from_stable_memory() -> bool {
+    with_memory(EVENT_STORE_EVENTS_MEMORY_ID, |memory| {
+        let reader = BufferedReader::new(ONE_MB, Reader::new(memory, 0));
+        match serde_cbor::from_reader(reader) {
+            Ok(client) => {
+                init(client);
+                true
+            }
+            Err(_) => false,
+        }
+    })
+}

--- a/src/kong_data/src/event_store_client/mod.rs
+++ b/src/kong_data/src/event_store_client/mod.rs
@@ -1,0 +1,1 @@
+pub mod event_store_client;

--- a/src/kong_data/src/lib.rs
+++ b/src/kong_data/src/lib.rs
@@ -4,6 +4,7 @@ mod canister;
 mod chains;
 mod claims;
 mod controllers;
+mod event_store_client;
 mod helpers;
 mod ic;
 mod pools;

--- a/src/kong_data/src/stable_memory.rs
+++ b/src/kong_data/src/stable_memory.rs
@@ -25,6 +25,7 @@ pub const REQUEST_MEMORY_ID: MemoryId = MemoryId::new(5);
 pub const TRANSFER_MEMORY_ID: MemoryId = MemoryId::new(6);
 pub const CLAIM_MEMORY_ID: MemoryId = MemoryId::new(7);
 pub const LP_TOKEN_MEMORY_ID: MemoryId = MemoryId::new(8);
+pub const EVENT_STORE_EVENTS_MEMORY_ID: MemoryId = MemoryId::new(9);
 
 pub const DB_UPDATE_MEMORY_ID: MemoryId = MemoryId::new(50);
 
@@ -91,4 +92,14 @@ thread_local! {
 /// A helper function to access the memory manager.
 pub fn with_memory_manager<R>(f: impl FnOnce(&MemoryManager<DefaultMemoryImpl>) -> R) -> R {
     MEMORY_MANAGER.with(|cell| f(&cell.borrow()))
+}
+
+/// A helper function to get read access to the memory.
+pub fn with_memory<R>(memory_id: MemoryId, f: impl FnOnce(&Memory) -> R) -> R {
+    with_memory_manager(|memory_manager| f(&memory_manager.get(memory_id)))
+}
+
+/// A helper function to get write access to the memory.
+pub fn with_memory_mut<R>(memory_id: MemoryId, f: impl FnOnce(&mut Memory) -> R) -> R {
+    with_memory_manager(|memory_manager| f(&mut memory_manager.get(memory_id)))
 }


### PR DESCRIPTION
## Description

This wires up the EventStoreClient within the archive canister so that it can be used to push events to the EventStore canister. The EventStore canister still needs to be created and its Id passed into the builder.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have adequate spec coverage of the changes and have manually tested them.
