### PR TITLE
remove bil from block list

### DIFF
--- a/src/kong_svelte/src/lib/components/swap/swap_ui/TokenSelectorDropdown.svelte
+++ b/src/kong_svelte/src/lib/components/swap/swap_ui/TokenSelectorDropdown.svelte
@@ -27,7 +27,7 @@
     tokens = $formattedTokens,
   } = props;
 
-  const BLOCKED_TOKEN_IDS = ['ktra4-taaaa-aaaag-atveq-cai'];
+  const BLOCKED_TOKEN_IDS = [];
   const DEFAULT_ICP_ID = "ryjl3-tyaaa-aaaaa-aaaba-cai"; // ICP canister ID
 
   let searchQuery = $state("");

--- a/src/kong_svelte/src/lib/services/swap/SwapService.ts
+++ b/src/kong_svelte/src/lib/services/swap/SwapService.ts
@@ -61,7 +61,7 @@ BigNumber.config({
   EXPONENTIAL_AT: [-50, 50],
 });
 
-const BLOCKED_TOKEN_IDS = ['ktra4-taaaa-aaaag-atveq-cai'];
+const BLOCKED_TOKEN_IDS = [];
 
 export class SwapService {
   private static isValidNumber(value: string | number): boolean {


### PR DESCRIPTION
This pull request includes changes to the `TokenSelectorDropdown.svelte` and `SwapService.ts` files to remove blocked token IDs.

Changes to blocked token IDs:

* [`src/kong_svelte/src/lib/components/swap/swap_ui/TokenSelectorDropdown.svelte`](diffhunk://#diff-962eb545f2eb90ce469f3532aaabcd30268b13c121eecb80dbe63faf942c663dL30-R30): Removed the blocked token ID `ktra4-taaaa-aaaag-atveq-cai` from the `BLOCKED_TOKEN_IDS` array.
* [`src/kong_svelte/src/lib/services/swap/SwapService.ts`](diffhunk://#diff-3608c0933b62c8611442b69eae672ac118666f98a65a94eebe6b35436bcee8dbL64-R64): Removed the blocked token ID `ktra4-taaaa-aaaag-atveq-cai` from the `BLOCKED_TOKEN_IDS` array.