### PR TITLE
fix(swap): remove modal implementation of onramp widget to fix ESC event key handling

### DIFF
--- a/src/kong_svelte/src/lib/components/swap/swap_ui/SwapPanel.svelte
+++ b/src/kong_svelte/src/lib/components/swap/swap_ui/SwapPanel.svelte
@@ -62,7 +62,6 @@
   let isMobile = $state(false);
   let lastBalanceCheck = $state<Record<string, number>>({});
   const DEBOUNCE_DELAY = 1000; // 1 second between balance checks
-  let showOnramperModal = $state(false);
 
   // Derived state using runes
   let tokenInfo = $derived(
@@ -362,10 +361,6 @@
         $swapState.tokenSelectorPosition?.y > windowHeight / 2 ? "up" : "down";
     }
   });
-
-  function toggleOnramperModal() {
-    showOnramperModal = !showOnramperModal;
-  }
 </script>
 
 <Panel
@@ -552,23 +547,6 @@
     </footer>
   </div>
 </Panel>
-
-<Modal
-  isOpen={showOnramperModal}
-  onClose={toggleOnramperModal}
-  title="Buy ICP with Fiat"
-  width="420px"
-  height="630px"
->
-  <iframe
-    src="https://buy.onramper.com/?apikey=pk_prod_01JHJ6KCSBFD6NEN8Q9PWRBKXZ&mode=buy"
-    title="Onramper Widget"
-    height="630px"
-    width="420px"
-    allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
-    class="w-full h-full"
-  />
-</Modal>
 
 <style lang="postcss">
   .clickable:hover {


### PR DESCRIPTION
This pull request includes changes to the `src/kong_svelte/src/lib/components/swap/swap_ui/SwapPanel.svelte` file, primarily focusing on the removal of the Onramper modal functionality when pressing ESC.

Removal of Onramper modal:

* Removed the `showOnramperModal` state variable.
* Deleted the `toggleOnramperModal` function.
* Removed the `Modal` component and its associated `iframe` for the Onramper widget.

With Onramper modal I mean this one:
![image](https://github.com/user-attachments/assets/3ec8fa01-b846-4b0a-bb4a-8e3725505165)

