### PR TITLE
remove disable logic for taggr in liquidity logic

### DIFF
--- a/src/kong_svelte/src/lib/components/liquidity/create_pool/CreateLiquidityPanel.svelte
+++ b/src/kong_svelte/src/lib/components/liquidity/create_pool/CreateLiquidityPanel.svelte
@@ -46,7 +46,6 @@
   const DEFAULT_TOKEN = "ICP";
   const SECONDARY_TOKEN_IDS = [ICP_CANISTER_ID, CKUSDT_CANISTER_ID];
   const DEBOUNCE_DELAY = 150; // Reduce from 300ms to improve responsiveness
-  const DISABLED_TOKEN_ADDRESS = "6qfxa-ryaaa-aaaai-qbhsq-cai";
   const MAX_BALANCE_LOAD_ATTEMPTS = 3; // Maximum number of times to try loading balances
   const MIN_BALANCE_LOAD_INTERVAL = 2000; // Minimum time (ms) between balance loads
 
@@ -96,7 +95,7 @@
   }
   
   // Determine button theme based on button text
-  $: buttonTheme = (buttonText === "Insufficient Balance" || buttonText === "Temporarily disabled") 
+  $: buttonTheme = (buttonText === "Insufficient Balance") 
     ? "accent-red" 
     : "accent-green";
   
@@ -740,11 +739,6 @@
                 Deposit Amounts
               {/if}
             </h3>
-            {#if token0.address === DISABLED_TOKEN_ADDRESS || token1.address === DISABLED_TOKEN_ADDRESS}
-              <div class="text-kong-error text-sm mb-4">
-                TAGGR is temporarily disabled. Please select different tokens.
-              </div>
-            {/if}
             <AmountInputs
               {token0}
               {token1}

--- a/src/kong_svelte/src/lib/utils/liquidityUtils.ts
+++ b/src/kong_svelte/src/lib/utils/liquidityUtils.ts
@@ -137,9 +137,6 @@ export function getButtonText(
 ): string {
     if (!token0 || !token1) return "Select Tokens";
     if (hasInsufficientBalance) return "Insufficient Balance";
-    if (token0.address === "6qfxa-ryaaa-aaaai-qbhsq-cai" || token1.address === "6qfxa-ryaaa-aaaai-qbhsq-cai") {
-        return "Temporarily disabled";
-    }
     if (!amount0 || !amount1) return "Enter Amounts";
     if (loading) return loadingState || "Loading...";
     return "Review Transaction";


### PR DESCRIPTION
This pull request simplifies the `CreateLiquidityPanel` component by removing logic and UI elements related to a disabled token address. It also improves responsiveness by reducing the debounce delay for balance updates.

### Simplification of disabled token logic:

* Removed the constant `DISABLED_TOKEN_ADDRESS` and its associated checks in `CreateLiquidityPanel.svelte`, including conditions that displayed a warning message when the disabled token was selected. (`src/kong_svelte/src/lib/components/liquidity/create_pool/CreateLiquidityPanel.svelte`, [[1]](diffhunk://#diff-def8dfb57b31e72d3a605a50d7b68c27177e492a91f896d6f5e87e3002ed4b58L49) [[2]](diffhunk://#diff-def8dfb57b31e72d3a605a50d7b68c27177e492a91f896d6f5e87e3002ed4b58L743-L747)
* Updated the `getButtonText` utility function to eliminate logic for returning "Temporarily disabled" when the disabled token address was detected. (`src/kong_svelte/src/lib/utils/liquidityUtils.ts`, [src/kong_svelte/src/lib/utils/liquidityUtils.tsL140-L142](diffhunk://#diff-02c6f76ccd2615931e27233c6c405056946f45316dffeb0281d4e2e12549ed20L140-L142))
* Adjusted the reactive `buttonTheme` assignment to remove dependency on the "Temporarily disabled" button text. (`src/kong_svelte/src/lib/components/liquidity/create_pool/CreateLiquidityPanel.svelte`, [src/kong_svelte/src/lib/components/liquidity/create_pool/CreateLiquidityPanel.svelteL99-R98](diffhunk://#diff-def8dfb57b31e72d3a605a50d7b68c27177e492a91f896d6f5e87e3002ed4b58L99-R98))